### PR TITLE
Type-annotate color attribute

### DIFF
--- a/src/tfont/objects/glyph.py
+++ b/src/tfont/objects/glyph.py
@@ -17,7 +17,8 @@ class Glyph:
 
     _layers: List[Layer] = attr.ib(default=attr.Factory(list))
 
-    color: Optional[Tuple] = attr.ib(default=None)
+    # Color format: RGBA8888.
+    color: Optional[Tuple[int, int, int, int]] = attr.ib(default=None)
     _extraData: Optional[Dict] = attr.ib(default=None)
 
     _lastModified: Optional[float] = attr.ib(default=None, init=False)

--- a/src/tfont/objects/layer.py
+++ b/src/tfont/objects/layer.py
@@ -36,7 +36,8 @@ class Layer:
     _guidelines: List[Guideline] = attr.ib(default=attr.Factory(list))
     _paths: List[Path] = attr.ib(default=attr.Factory(list))
 
-    color: Optional[Tuple] = attr.ib(default=None)
+    # Color format: RGBA8888.
+    color: Optional[Tuple[int, int, int, int]] = attr.ib(default=None)
     _extraData: Optional[Dict] = attr.ib(default=None)
 
     _bounds: Optional[Tuple] = attr.ib(default=None, init=False)


### PR DESCRIPTION
Needed for structuring. Otherwise you always get a `()` instead of colors.